### PR TITLE
Implement no_encoding_error options, to pass to pg_verify_mbstr avoiding errors

### DIFF
--- a/db2_fdw.c
+++ b/db2_fdw.c
@@ -180,6 +180,7 @@ struct DB2FdwOption
 #define OPT_KEY "key"
 #define OPT_SAMPLE "sample_percent"
 #define OPT_PREFETCH "prefetch"
+#define OPT_NO_ENCODING_ERROR "no_encoding_error"
 
 #define DEFAULT_MAX_LONG 32767
 #define DEFAULT_PREFETCH 200
@@ -205,6 +206,9 @@ static struct DB2FdwOption valid_options[] = {
   {OPT_SAMPLE, ForeignTableRelationId, false},
   {OPT_PREFETCH, ForeignTableRelationId, false}
   , {OPT_KEY, AttributeRelationId, false}
+  , {OPT_NO_ENCODING_ERROR, ForeignDataWrapperRelationId, false}
+  , {OPT_NO_ENCODING_ERROR, ForeignTableRelationId, false}
+  , {OPT_NO_ENCODING_ERROR, AttributeRelationId, false}
 };
 
 #define option_count (sizeof(valid_options)/sizeof(struct DB2FdwOption))
@@ -343,7 +347,6 @@ static Const *serializeLong (long i);
 static struct DB2FdwState *deserializePlanData (List * list);
 static char *deserializeString (Const * constant);
 static long deserializeLong (Const * constant);
-static bool optionIsTrue (const char *value);
 #if PG_VERSION_NUM >= 150000
 static Expr *find_em_expr_for_rel (EquivalenceClass * ec, RelOptInfo * rel);
 #endif
@@ -448,8 +451,8 @@ db2_fdw_validator (PG_FUNCTION_ARGS)
       ereport (ERROR, (errcode (ERRCODE_FDW_INVALID_OPTION_NAME), errmsg ("invalid option \"%s\"", def->defname), errhint ("Valid options in this context are: %s", buf.data)));
     }
 
-    /* check valid values for "readonly" and "key" */
-    if (strcmp (def->defname, OPT_READONLY) == 0 || strcmp (def->defname, OPT_KEY) == 0) {
+    /* check valid values for "readonly", "key" and "no_encoding_error" */
+    if (strcmp (def->defname, OPT_READONLY) == 0 || strcmp (def->defname, OPT_KEY) == 0 || strcmp (def->defname, OPT_NO_ENCODING_ERROR) == 0) {
       char *val = STRVAL(def->arg);
       if (pg_strcasecmp (val, "on") != 0
 	  && pg_strcasecmp (val, "off") != 0
@@ -2140,7 +2143,7 @@ getFdwState (Oid foreigntableid, double *sample_percent)
   char *pgtablename = get_rel_name (foreigntableid);
   List *options;
   ListCell *cell;
-  char *schema = NULL, *table = NULL, *maxlong = NULL, *sample = NULL, *fetch = NULL;
+  char *schema = NULL, *table = NULL, *maxlong = NULL, *sample = NULL, *fetch = NULL, *noencerr = NULL;
   long max_long;
 
   /*
@@ -2168,6 +2171,8 @@ getFdwState (Oid foreigntableid, double *sample_percent)
       sample = STRVAL(def->arg);
     if (strcmp (def->defname, OPT_PREFETCH) == 0)
       fetch = STRVAL(def->arg);
+    if (strcmp (def->defname, OPT_NO_ENCODING_ERROR) == 0)
+      noencerr = STRVAL(def->arg);
   }
 
   /* convert "max_long" option to number or use default */
@@ -2203,7 +2208,7 @@ getFdwState (Oid foreigntableid, double *sample_percent)
     );
 
   /* get remote table description */
-  fdwState->db2Table = db2Describe (fdwState->session, schema, table, pgtablename, max_long);
+  fdwState->db2Table = db2Describe (fdwState->session, schema, table, pgtablename, max_long, noencerr);
 
   /* add PostgreSQL data to table description */
   getColumnData (fdwState->db2Table, foreigntableid);
@@ -2291,6 +2296,11 @@ getColumnData (struct db2Table *db2Table, Oid foreigntableid)
       if (strcmp (def->defname, OPT_KEY) == 0 && optionIsTrue ((STRVAL(def->arg)))) {
 	/* mark the column as primary key column */
 	db2Table->cols[index - 1]->pkey = 1;
+      }
+
+      /* is it the "no_encoding_error" option set ? */
+      if (strcmp (def->defname, OPT_NO_ENCODING_ERROR) == 0) {
+	db2Table->cols[index - 1]->noencerr = optionIsTrue ((STRVAL(def->arg))) ? NO_ENC_ERR_TRUE : NO_ENC_ERR_FALSE;
       }
     }
   }
@@ -4390,6 +4400,7 @@ List * serializePlanData (struct DB2FdwState * fdwState)
     result = lappend (result, serializeInt (fdwState->db2Table->cols[i]->used));
     result = lappend (result, serializeInt (fdwState->db2Table->cols[i]->pkey));
     result = lappend (result, serializeLong (fdwState->db2Table->cols[i]->val_size));
+    result = lappend (result, serializeInt (fdwState->db2Table->cols[i]->noencerr));
     /* don't serialize val, val_len, val_len4, val_null and varno */
   }
 
@@ -4526,6 +4537,8 @@ deserializePlanData (List * list)
     state->db2Table->cols[i]->pkey = (int) DatumGetInt32 (((Const *) lfirst (cell))->constvalue);
     cell = list_next (list,cell);
     state->db2Table->cols[i]->val_size = deserializeLong (lfirst (cell));
+    cell = list_next (list,cell);
+    state->db2Table->cols[i]->noencerr = (int) DatumGetInt32 (((Const *) lfirst (cell))->constvalue);
     cell = list_next (list,cell);
     /* allocate memory for the result value */
     state->db2Table->cols[i]->val = (char *) palloc (state->db2Table->cols[i]->val_size + 1);
@@ -4793,6 +4806,7 @@ copyPlanData (struct DB2FdwState *orig)
     copy->db2Table->cols[i]->val_len = 0;
     copy->db2Table->cols[i]->val_len4 = 0;
     copy->db2Table->cols[i]->val_null = 0;
+    copy->db2Table->cols[i]->noencerr = orig->db2Table->cols[i]->noencerr;
   }
   copy->startup_cost = 0.0;
   copy->total_cost = 0.0;
@@ -5229,7 +5243,7 @@ convertTuple (struct DB2FdwState *fdw_state, Datum * values, bool * nulls, bool 
 
       /* for string types, check that the data are in the database encoding */
       if (pgtype == BPCHAROID || pgtype == VARCHAROID || pgtype == TEXTOID)
-	(void) pg_verify_mbstr (GetDatabaseEncoding (), value, value_len, false);
+	(void) pg_verify_mbstr (GetDatabaseEncoding (), value, value_len, fdw_state->db2Table->cols[index]->noencerr == NO_ENC_ERR_TRUE);
 
       /* call the type input function */
       switch (pgtype) {

--- a/db2_fdw.h
+++ b/db2_fdw.h
@@ -12,6 +12,7 @@
 /* this one is safe to include and gives us Oid */
 #include "postgres_ext.h"
 
+#include <stdbool.h>
 #include <sys/types.h>
 
 /* db2_fdw version */
@@ -95,6 +96,12 @@ typedef enum
 #define UUIDOID 2950
 #endif
 
+typedef enum {
+  NO_ENC_ERR_NULL,
+  NO_ENC_ERR_TRUE,
+  NO_ENC_ERR_FALSE
+} db2NoEncErrType;
+
 struct db2Column
 {
   char *name;			/* name in DB2 */
@@ -112,6 +119,7 @@ struct db2Column
   unsigned int val_len4;	/* actual length of val - for bind callbacks */
   short val_null;		/* indicator for NULL value */
   int varno;			/* range table index of this column's relation */
+  db2NoEncErrType noencerr;	/* no encoding error produced */
 };
 
 struct db2Table
@@ -169,7 +177,7 @@ extern void db2Cancel (void);
 extern void db2EndTransaction (void *arg, int is_commit, int silent);
 extern void db2EndSubtransaction (void *arg, int nest_level, int is_commit);
 extern int db2IsStatementOpen (db2Session * session);
-extern struct db2Table *db2Describe (db2Session * session, char *schema, char *table, char *pgname, long max_long);
+extern struct db2Table *db2Describe (db2Session * session, char *schema, char *table, char *pgname, long max_long, char *noencerr);
 extern void db2ExplainOLD (db2Session * session, const char *query, int *nrows, char ***plan);
 extern void db2PrepareQuery (db2Session * session, const char *query, const struct db2Table *db2Table, unsigned int prefetch);
 extern int db2ExecuteQuery (db2Session * session, const struct db2Table *db2Table, struct paramDesc *paramList);
@@ -196,3 +204,4 @@ extern void db2Debug2 (const char *message,...);
 extern void db2Debug3 (const char *message,...);
 extern void db2Debug4 (const char *message,...);
 extern void db2Debug5 (const char *message,...);
+extern bool optionIsTrue (const char *value);

--- a/db2_utils.c
+++ b/db2_utils.c
@@ -869,7 +869,7 @@ db2IsStatementOpen (db2Session * session)
  * 		Returns a palloc'ed data structure with the results.
  */
 struct db2Table *
-db2Describe (db2Session * session, char *schema, char *table, char *pgname, long max_long)
+db2Describe (db2Session * session, char *schema, char *table, char *pgname, long max_long, char *noencerr)
 {
   struct db2Table *reply;
   ub2 Type;
@@ -959,6 +959,15 @@ db2Describe (db2Session * session, char *schema, char *table, char *pgname, long
     reply->cols[i - 1]->val = NULL;
     reply->cols[i - 1]->val_len = 0;
     reply->cols[i - 1]->val_null = 1;
+    reply->cols[i - 1]->noencerr = NO_ENC_ERR_NULL;
+
+    if (noencerr != NULL) {
+      if (optionIsTrue(noencerr)) {
+	reply->cols[i - 1]->noencerr = NO_ENC_ERR_TRUE;
+     } else {
+	reply->cols[i - 1]->noencerr = NO_ENC_ERR_FALSE;
+     }
+    }
 
     /* get the parameter descriptor for the column */
     if (checkerr (OCIParamGet ((void *) stmthp, OCI_HTYPE_STMT, session->envp->errhp, (dvoid **) & colp, i), (dvoid *) session->envp->errhp, OCI_HTYPE_ERROR,__LINE__, __FILE__) != OCI_SUCCESS) {


### PR DESCRIPTION
Hi Wolfgang,

I had problems with dirty data in a customer DB/2, so I implemented this little patch to avoid encoding errors calling pg_verify_mbstr.

I added a new variable `noencerr` in the column data (i.e. `struct db2Column`), that I set through options at FDW, table or column level.

Please verify the code before merging, as I'm not so sure that I modified all the places where column data is referenced!